### PR TITLE
add cookie support as required by latest s/w

### DIFF
--- a/hstatus.py
+++ b/hstatus.py
@@ -18,9 +18,13 @@ def to_size(size):
    return '%s %s' % (s,size_name[i])
 
 
-def is_hilink(device_ip):
+def is_hilink(device_ip, token, sessionID):
+    headers = {}
+    if token is not None and sessionID is not None:
+        # headers = {'__RequestVerificationToken': token}
+        headers = {'Cookie': sessionID}
     try:
-        r = requests.get(url='http://' + device_ip + '/api/device/information', allow_redirects=False, timeout=(2.0,2.0))
+        r = requests.get(url='http://' + device_ip + '/api/device/information', headers=headers, allow_redirects=False, timeout=(2.0,2.0))
     except requests.exceptions.RequestException as e:
         return False;
 
@@ -29,24 +33,30 @@ def is_hilink(device_ip):
     return True
 
 def get_token(device_ip):
+    sessionID = None
     token = None
     try:
-        r = requests.get(url='http://' + device_ip + '/api/webserver/token', allow_redirects=False, timeout=(2.0,2.0))
+        r = requests.get(url='http://' + device_ip + '/api/webserver/SesTokInfo', allow_redirects=False, timeout=(2.0,2.0))
     except requests.exceptions.RequestException as e:
-        return token
-    try:        
+        return (token, sessionID)
+
+    try:
         d = xmltodict.parse(r.text, xml_attribs=True)
-        if 'response' in d and 'token' in d['response']:
-            token = d['response']['token']
+        if 'response' in d and 'TokInfo' in d['response']:
+            token = d['response']['TokInfo']
+            d = xmltodict.parse(r.text, xml_attribs=True)
+        if 'response' in d and 'SesInfo' in d['response']:
+            sessionID = d['response']['SesInfo']
     except:
         pass
-    return token
-    
+    return (token, sessionID)
 
-def call_api(device_ip, token, resource, xml_attribs=True):
+
+def call_api(device_ip, token, sessionID, resource, xml_attribs=True):
     headers = {}
-    if token is not None:
-        headers = {'__RequestVerificationToken': token}
+    if token is not None and sessionID is not None:
+        # headers = {'__RequestVerificationToken': token}
+        headers = {'Cookie': sessionID}
     try:
         r = requests.get(url='http://' + device_ip + resource, headers=headers, allow_redirects=False, timeout=(2.0,2.0))
     except requests.exceptions.RequestException as e:
@@ -57,7 +67,7 @@ def call_api(device_ip, token, resource, xml_attribs=True):
         d = xmltodict.parse(r.text, xml_attribs=xml_attribs)
         if 'error' in d:
             raise Exception('Received error code ' + d['error']['code'] + ' for URL ' + r.url)
-        return d            
+        return d
     else:
       raise Exception('Received status code ' + str(r.status_code) + ' for URL ' + r.url)
 
@@ -163,8 +173,8 @@ def get_signal_level(level):
         result = u'\u2581' + u'\u2583' + u'\u2584' + u'\u2586' + u'\u2588'
     return result
 
-def print_traffic_statistics(device_ip, token, connection_status):
-    d = call_api(device_ip, token, '/api/monitoring/traffic-statistics')
+def print_traffic_statistics(device_ip, token, sessionID, connection_status):
+    d = call_api(device_ip, token, sessionID, '/api/monitoring/traffic-statistics')
     current_connect_time = d['response']['CurrentConnectTime']
     current_upload = d['response']['CurrentUpload']
     current_download = d['response']['CurrentDownload']
@@ -178,8 +188,8 @@ def print_traffic_statistics(device_ip, token, connection_status):
     print('  Total downloaded: ' + to_size(float(total_download)))
     print('  Total uploaded: ' + to_size(float(total_upload)))
 
-def print_connection_status(device_ip, token):
-    d = call_api(device_ip, token, '/api/monitoring/status')
+def print_connection_status(device_ip, token, sessionID):
+    d = call_api(device_ip, token, sessionID, '/api/monitoring/status')
     connection_status = d['response']['ConnectionStatus']
     signal_strength = d['response']['SignalStrength']
     signal_level = d['response']['SignalIcon']
@@ -216,8 +226,8 @@ def print_connection_status(device_ip, token):
 
     return connection_status
 
-def print_device_info(device_ip, token):
-    d = call_api(device_ip, token, '/api/device/information')
+def print_device_info(device_ip, token, sessionID):
+    d = call_api(device_ip, token, sessionID, '/api/device/information')
     device_name = d['response']['DeviceName']
     serial_number = d['response']['SerialNumber']
     imei = d['response']['Imei']
@@ -227,7 +237,7 @@ def print_device_info(device_ip, token):
     mac_address1 = d['response']['MacAddress1']
     mac_address2 = d['response']['MacAddress2']
     product_family = d['response']['ProductFamily']
- 
+
     print('Huawei ' + device_name + ' ' + product_family + ' Modem (IMEI: ' + imei + ')')
     print('  Hardware version: ' + hardware_version)
     print('  Software version: ' + software_version)
@@ -239,39 +249,42 @@ def print_device_info(device_ip, token):
     else:
         print('')
 
-def print_provider(device_ip, token, connection_status):
+def print_provider(device_ip, token, sessionID, connection_status):
     if connection_status == '901':
-        d = call_api(device_ip, token, '/api/net/current-plmn')
+        d = call_api(device_ip, token, sessionID, '/api/net/current-plmn')
         state = d['response']['State']
         provider_name = d['response']['FullName']
         print('    Network operator: ' + provider_name)
 
-def print_unread(device_ip, token):
-    d = call_api(device_ip, token, '/api/monitoring/check-notifications')
+def print_unread(device_ip, token, sessionID):
+    d = call_api(device_ip, token, sessionID, '/api/monitoring/check-notifications')
     unread_messages = d['response']['UnreadMessage']
     if unread_messages is not None and int(unread_messages) > 0:
         print('  Unread SMS: ' + unread_messages)
 
-device_ip = '192.168.1.1'
-if len(sys.argv) == 2:
-    device_ip = sys.argv[1]
-    if not is_hilink(device_ip):
-        print("Can't find a Huawei HiLink device on " + device_ip)
-        print('')
-        sys.exit(-1)
-else:
-    if not is_hilink(device_ip):
-        if not is_hilink('192.168.8.1'):
-            print("Can't find a Huawei HiLink device on the default IP addresses, please try again and pass the device's IP address as a parameter")
-            print('')
-            sys.exit(-1)
-        else:
-            device_ip = '192.168.8.1'
+device_ip = '192.168.8.1'
 
-token = get_token(device_ip)
-print_device_info(device_ip, token)
-connection_status = print_connection_status(device_ip, token)
-print_provider(device_ip, token, connection_status)
-print_traffic_statistics(device_ip, token, connection_status)
-print_unread(device_ip, token)
+token, sessionID = get_token(device_ip)
+
+# if len(sys.argv) == 2:
+    # device_ip = sys.argv[1]
+    # if not is_hilink(device_ip, token, sessionID):
+        # print("Can't find a Huawei HiLink device on " + device_ip)
+        # print('')
+        # sys.exit(-1)
+# else:
+    # if not is_hilink(device_ip, token, sessionID):
+        # if not is_hilink('192.168.8.1', token, sessionID):
+            # print("Can't find a Huawei HiLink device on the default IP addresses, please try again and pass the device's IP address as a parameter")
+            # print('')
+            # sys.exit(-1)
+        # else:
+            # device_ip = '192.168.8.1'
+
+print_device_info(device_ip, token, sessionID)
+connection_status = print_connection_status(device_ip, token, sessionID)
+print_provider(device_ip, token, sessionID, connection_status)
+print_traffic_statistics(device_ip, token, sessionID, connection_status)
+print_unread(device_ip, token, sessionID)
+
 print('')


### PR DESCRIPTION
The HiLink s/w now require the sessionID to be passed with each api request. This is the issue reported in #3 

The following PR works on:

Huawei E3372 LTE Modem
Hardware version: CL2E3372HM
Software version: 22.315.01.00.74
Web UI version: 17.100.14.00.74

Signal strength reporting has also changed and this is not working. Further investigation needed.

Code changes based on:
https://trick77.com/query-status-information-huaweis-hilink-3g-lte-modems/#comment-13770
